### PR TITLE
choice of EOS function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@
 
 Compatibility with the built-in tests requires Julia 1.6+. 
 
-## Installation (from jrayshi)
+# Installation (from jrayshi)
 pkg> add IsopycnalSurfaces (not working)
 
 Optional:
-cd ./IsopycnalSurfaces.jl
+cd ./IsopycnalSurfaces.jl\
 pkg> activate .
 
 # Setting up project environment

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@
 
 Compatibility with the built-in tests requires Julia 1.6+. 
 
+## Installation (from jrayshi)
+pkg> add IsopycnalSurfaces (not working)
+
+Optional:
+cd ./IsopycnalSurfaces.jl
+pkg> activate .
+
 # Setting up project environment
 
 Details about setting up a Julia environment are available at https://github.com/ggebbie/ECCOtour.jl#readme .
@@ -74,3 +81,11 @@ Run the following Julia code
     `git push -u origin main`
 
 4. Use Documenter.jl and DocumenterTools to automatically deploy documentation following: https://m3g.github.io/JuliaNotes.jl/stable/publish_docs/ .
+
+
+
+
+
+
+
+

--- a/src/IsopycnalSurfaces.jl
+++ b/src/IsopycnalSurfaces.jl
@@ -141,7 +141,7 @@ end
 # Output
 - `σ₀`:  sigma-0 for wet points in column
 """
-sigma0column(θz,Sz,pz=missing) = ismissing(eos) ? sigmacolumn(θz,Sz,pz,0) : sigmacolumn(θz,Sz,pz,0,eos)
+sigma0column(θz,Sz,pz,eos=missing) = ismissing(eos) ? sigmacolumn(θz,Sz,pz,0) : sigmacolumn(θz,Sz,pz,0,eos)
 
 """
     function sigma1column(θ,S,p)

--- a/src/IsopycnalSurfaces.jl
+++ b/src/IsopycnalSurfaces.jl
@@ -4,7 +4,7 @@ using Dierckx, Interpolations
 
 export sigma0column, sigma1column, sigma2column,
  vars2sigma1,  var2sigmacolumn, sigma1grid,
- mixinversions!, dedup!
+ mixinversions!, dedup!, density, sigmacolumn
 
 """
     function vars2sigma1(vars,p,sig1grid,γ,spline_order)
@@ -112,12 +112,20 @@ end
 # Output
 - `σ::Vector{T}`:  sigma for wet points in column
 """
-function sigmacolumn(θz::Vector{T},Sz::Vector{T},pz::Vector{T2},p0::Integer)::Vector{T} where T<:AbstractFloat where T2<:AbstractFloat
+function sigmacolumn(θz::Vector{T},Sz::Vector{T},pz::Vector{T2},p0::Integer, eos=missing)::Vector{T} where T<:AbstractFloat where T2<:AbstractFloat
     nz = length(θz)
     σ = similar(θz)
     
-    σa,σb,σc = SeaWaterDensity(θz,Sz,pz,p0)
-    [σ[zz] = convert(T,σc[zz]) .- 1000.0 for zz = 1:nz]
+    # choose EOS method, added by Ray Dec 09 2021
+    if ismissing(eos)
+        σ = density.(Sz,θz,p0) .- 1000.
+    elseif eos == "EOS94"
+        σa,σb,σc = SeaWaterDensity(θz,Sz,pz,p0)
+        [σ[zz] = convert(T,σc[zz]) .- 1000.0 for zz = 1:nz]
+    else
+        error("The entered EOS is not supported currently, please try the supported one, like EOS94")
+    end
+
     return σ
 end
 
@@ -133,7 +141,7 @@ end
 # Output
 - `σ₀`:  sigma-0 for wet points in column
 """
-sigma0column(θz,Sz,pz) = sigmacolumn(θz,Sz,pz,0)
+sigma0column(θz,Sz,pz=missing) = ismissing(eos) ? sigmacolumn(θz,Sz,pz,0) : sigmacolumn(θz,Sz,pz,0,eos)
 
 """
     function sigma1column(θ,S,p)
@@ -147,7 +155,7 @@ sigma0column(θz,Sz,pz) = sigmacolumn(θz,Sz,pz,0)
 # Output
 - `σ₁`:  sigma-1 for wet points in column
 """
-sigma1column(θz,Sz,pz) = sigmacolumn(θz,Sz,pz,1000)
+sigma1column(θz,Sz,pz,eos=missing) = ismissing(eos) ? sigmacolumn(θz,Sz,pz,1000) : sigmacolumn(θz,Sz,pz,1000,eos)
 
 """
     function sigma2column(θ,S,p)
@@ -161,7 +169,8 @@ sigma1column(θz,Sz,pz) = sigmacolumn(θz,Sz,pz,1000)
 # Output
 - `σ₂`:  sigma-2 for wet points in column
 """
-sigma2column(θz,Sz,pz) = sigmacolumn(θz,Sz,pz,2000)
+# revised by Ray, Dec 09 2021
+sigma2column(θz,Sz,pz,eos=missing) = ismissing(eos) ? sigmacolumn(θz,Sz,pz,2000) : sigmacolumn(θz,Sz,pz,2000,eos)
 
 """
    function notnanorzero
@@ -404,5 +413,148 @@ function SeaWaterDensity(Θ,Σ,Π,Π0=missing)
 
    return ρP,ρI,ρR
 end
+
+
+
+"""
+density(S,T,p) and dependent functions from PhysOcean.jl/EOS80.jl, From Alexander Barth
+
+Compute the density of sea-water (kg/m³) at the salinity `S` (psu, PSS-78), temperature `T` (degree Celsius, ITS-90) and pressure `p` (decibar) using the UNESCO 1983 polynomial.
+
+Reference: Fofonoff, N.P.; Millard, R.C. (1983). Algorithms for computation of fundamental properties of seawater. UNESCO Technical Papers in Marine Science, No. 44. UNESCO: Paris. 53 pp.
+http://web.archive.org/web/20170103000527/http://unesdoc.unesco.org/images/0005/000598/059832eb.pdf
+
+```
+Check value: ρI = `1041.87651kg/m^3` for Θ=`3°Celcius`, Σ=`35.5psu`, Π=`3000dbar`
+ρI = density(35.5, 3, 3000)
+```
+added by Ray, Dec 09, 2021
+"""
+function density(S,T,p)
+    ρ = density0(S,T)
+
+    if (p == 0)
+        return ρ
+    end
+
+    K = secant_bulk_modulus(S,T,p)
+    # convert decibars to bars
+    p = p/10
+    return ρ / (1 - p/K)
+end
+
+"""
+    temperature68(T)
+Convert temperature `T` from ITS-90 scale to the IPTS-68 scale following Saunders, 1990.
+Saunders, P.M. 1990, The International Temperature Scale of 1990, ITS-90. No.10, p.10.
+https://web.archive.org/web/20170304194831/http://webapp1.dlib.indiana.edu/virtual_disk_library/index.cgi/4955867/FID474/wocedocs/newsltr/news10/news10.pdf
+"""
+temperature68(T) = 1.00024 * T
+
+"""
+    density_reference_pure_water(T)
+density of pure water at the temperature `T` (degree Celsius, ITS-90)
+"""
+function density_reference_pure_water(T)
+
+    t = temperature68(T)
+
+    # page 21, equation 14 of
+    # http://web.archive.org/web/20170103000527/http://unesdoc.unesco.org/images/0005/000598/059832eb.pdf
+
+    a0 = 999.842594 # why [-28.263737]
+    a1 = 6.793952e-2
+    a2 = -9.095290e-3
+    a3 = 1.001685e-4
+    a4 = -1.120083e-6
+    a5 = 6.536332e-9
+
+    ρ_w = a0 + (a1 + (a2 + (a3 + (a4 + a5 * t) * t) * t) * t) * t
+    return ρ_w
+end
+
+function density0(S,T)
+    t = temperature68(T)
+    # page 21, equation (13) of
+    # http://web.archive.org/web/20170103000527/http://unesdoc.unesco.org/images/0005/000598/059832eb.pdf
+
+    b0 = 8.24493e-1
+    b1 = -4.0899e-3
+    b2 = 7.6438e-5
+    b3 = -8.2467e-7
+    b4 = 5.3875e-9
+    c0 = -5.72466e-3
+    c1 = 1.0227e-4
+    c2 = -1.6546e-6
+    d0 = 4.8314e-4
+
+    ρ = density_reference_pure_water(T) + ((b0 + (b1 + (b2 + (b3 + b4 * t) * t) * t) * t) + (c0 + (c1 + c2 * t) * t) * sqrt(S) + d0 * S) * S;
+    return ρ
+end
+"""
+    secant_bulk_modulus(S,T,p)
+Compute the secant bulk modulus of sea-water (bars) at the salinity `S` (psu, PSS-78), temperature `T` (degree Celsius, ITS-90) and pressure `p` (decibar) using the UNESCO polynomial 1983.
+Fofonoff, N.P.; Millard, R.C. (1983). Algorithms for computation of fundamental properties of seawater. UNESCO Technical Papers in Marine Science, No. 44. UNESCO: Paris. 53 pp.
+http://web.archive.org/web/20170103000527/http://unesdoc.unesco.org/images/0005/000598/059832eb.pdf
+"""
+function secant_bulk_modulus(S,T,p)
+    # convert decibars to bars
+    p = p/10
+
+    t = temperature68(T)
+
+    # page 18, equation (19)
+    e0 = +19652.21 # [-1930.06]
+    e1 = +148.4206
+    e2 = -2.327105
+    e3 = +1.360477E-2
+    e4 = -5.155288E-5
+    Kw = e0 + (e1  + (e2 + (e3  + e4 * t) * t) * t) * t
+
+    # page 18, equation (16)
+    # probably typo f3 vs f2
+    f0 = +54.6746;    g0 = +7.944E-2
+    f1 = -0.603459;   g1 = +1.6483E-2
+    f2 = +1.09987E-2; g2 = -5.3009E-4
+    f3 = -6.1670E-5
+
+    K0 = Kw + ((f0 + (f1 + (f2  + f3 * t) * t) * t) + (g0 + (g1 + g2 * t) * t) * sqrt(S)) * S
+
+    if (p == 0)
+        return K0
+    end
+
+    # page 19
+    h0 = +3.239908 # [-0.1194975]
+    h1 = +1.43713E-3
+    h2 = +1.16092E-4
+    h3 = -5.77905E-7
+    Aw = h0 + (h1 + (h2 + h3 * t) * t) * t
+
+
+    k0 = +8.50935E-5 # [+ 3.47718E-5]
+    k1 = -6.12293E-6
+    k2 = +5.2787E-8
+    Bw = k0 + (k1 + k2 * t) * t
+
+    # page 18, equation (17)
+    i0 = +2.2838E-3; j0 = +1.91075E-4
+    i1 = -1.0981E-5
+    i2 = -1.6078E-6
+    A = Aw + ((i0 + (i1 + i2 * t) * t) + j0 * sqrt(S)) * S
+
+    # page 18, equation (18)
+    m0 = -9.9348E-7
+    m1 = +2.0816E-8
+    m2 = +9.1697E-10
+    B = Bw + (m0 + (m1 + m2 * t) * t) * S
+
+    K = K0 + (A + B * p) * p
+
+    return K
+end
+
+
+
 
 end

--- a/test/runtest_r1.jl
+++ b/test/runtest_r1.jl
@@ -1,0 +1,25 @@
+using Revise
+using IsopycnalSurfaces, Test
+
+@testset "IsopycnalSurfaces.jl" begin
+    #############################
+    # Test dedup! function
+    @testset "deduplication" begin
+        na = 10
+        for ndupes = 1:na-1
+            println(ndupes)
+            a = sort(randn(na))
+            b = randn(na)
+            # make duplicates at end
+            counter = 0
+            while counter < ndupes  
+                a[end-counter-1] = a[end-counter]
+                counter += 1
+            end
+            dedup!(a,b)
+            println(a)
+            println(b)
+            println(@test issorted(a))
+        end
+    end
+end

--- a/test/runtest_r2.jl
+++ b/test/runtest_r2.jl
@@ -1,0 +1,40 @@
+using Revise
+using IsopycnalSurfaces, Test
+
+@testset "IsopycnalSurfaces.jl" begin
+    #############################
+    # Test dedup! function
+    @testset "column" begin
+        ################################
+        # Idealized mapping onto sigma1
+        pz = collect(0.:500.:4000.) # pressure levels
+        nz = length(pz)
+
+        θz = collect(range(20,stop=10,length=nz))
+        Sz = collect(range(36,stop=35,length=nz))
+        ztest = sort(rand(2:8,2))
+        σ₁true = sigma1column(θz[ztest],Sz[ztest],pz[ztest])
+
+        σ₁grid = range(minimum(σ₁true),stop=maximum(σ₁true),length=20)
+        σ₁=sigma1column(θz,Sz,pz)
+
+        @testset "column_spline" begin
+            splorder = 3
+            sgood = findall(minimum(σ₁) .<= σ₁grid .<= maximum(σ₁))
+            pσ = var2sigmacolumn(σ₁,pz,σ₁grid[sgood],splorder)
+
+            @test isapprox(pσ[begin],pz[ztest[begin]])
+            @test isapprox(pσ[end],pz[ztest[end]])
+        end
+
+        @testset "column_linear" begin
+            splorder = 100
+            sgood = findall(minimum(σ₁) .<= σ₁grid .<= maximum(σ₁))
+            pσ = var2sigmacolumn(σ₁,pz,σ₁grid[sgood],splorder)
+
+            @test isapprox(pσ[begin],pz[ztest[begin]])
+            @test isapprox(pσ[end],pz[ztest[end]])
+        end
+
+    end
+end

--- a/test/runtest_r3.jl
+++ b/test/runtest_r3.jl
@@ -1,0 +1,49 @@
+using Revise
+using IsopycnalSurfaces, Test
+
+@testset "IsopycnalSurfaces.jl" begin
+    # test input from a 3D array (failed Dec 09 2021)
+    @testset "3d_array" begin
+
+        # currently empty
+        pz = collect(0.:500.:4000.) # pressure levels
+        nz = length(pz)
+
+        θz = collect(range(20,stop=10,length=nz))
+        Sz = collect(range(36,stop=35,length=nz))
+
+        ztest = sort(rand(2:8,2))
+        σ₁true = sigma1column(θz[ztest],Sz[ztest],pz[ztest])
+
+        # put θ,S,p into 3D array
+        nx = 10; ny = 10;
+        θ = Array{Float64,3}(undef,nx,ny,nz)
+        S = Array{Float64,3}(undef,nx,ny,nz)
+        p = Array{Float64,3}(undef,nx,ny,nz)
+        
+        [θ[i,j,k] = θz[k] for i = 1:nx for j = 1:ny for k = 1:nz ]
+        [S[i,j,k] = Sz[k] for i = 1:nx for j = 1:ny for k = 1:nz ]
+        [p[i,j,k] = pz[k] for i = 1:nx for j = 1:ny for k = 1:nz ]
+
+        σ₁grid = collect(range(minimum(σ₁true),stop=maximum(σ₁true),length=20))
+
+        vars = Dict("θ" => θ, "Sp" => S)
+
+        @testset "3d_array_spline" begin
+            splorder = 3
+            varsσ = vars2sigma1(vars,pz,σ₁grid,splorder)
+            xx = rand(1:nx); yy = rand(1:ny)
+            @test isapprox(varsσ["p"][xx,yy,begin],pz[ztest[begin]])
+            @test isapprox(varsσ["p"][xx,yy,end],pz[ztest[end]])
+        end
+
+        @testset "3d_array_linear" begin
+            splorder = 3
+            linearinterp = true
+            varsσ = vars2sigma1(vars,pz,σ₁grid,splorder,linearinterp)
+            xx = rand(1:nx); yy = rand(1:ny)
+            @test isapprox(varsσ["p"][xx,yy,begin],pz[ztest[begin]])
+            @test isapprox(varsσ["p"][xx,yy,end],pz[ztest[end]])
+        end
+    end
+end

--- a/test/runtest_rayEOS.jl
+++ b/test/runtest_rayEOS.jl
@@ -1,0 +1,15 @@
+using Revise
+using IsopycnalSurfaces, Test
+
+pz = collect(0.:500.:4000.) # pressure levels
+nz = length(pz)
+θz = collect(range(20,stop=10,length=nz))
+Sz = collect(range(36,stop=35,length=nz))
+
+
+println("Using the EOS from MITgcmTools.jl:")
+display(sigma2column(θz,Sz,pz,"EOS94")) # using the EOS from MITgcmTools.jl
+println("")
+println("Default, using the EOS from PhysOcean.jl/EOS80.jl:")
+display(sigma2column(θz,Sz,pz))  # default, using the EOS from PhysOcean.jl/EOS80.jl
+


### PR DESCRIPTION
The EOS functions from PhysOcean.jl/EOS80.jl are added as default EOS to calculate sigma. 

The EOS from MITgcmTools.jl can be chosen with "EOS94". For example, sigma2column(θz,Sz,pz,"EOS94").
